### PR TITLE
update release yaml to avoid upper case issues regarding reponame

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   build:
+    env:
+      REPO: jonas80/swt-project
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,5 +50,5 @@ jobs:
         with:
           context: ${{ matrix.project }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository }}/${{ matrix.project }}:${{ github.sha }}
+          tags: ghcr.io/${{ env.REPO }}/${{ matrix.project }}:${{ github.sha }}
           labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
## Summary
changed github release action to use environment variable instead of repository name to avoid issues on publish docker image
