### PR TITLE
Refactor AppUserController to use Spring Security Authentication

### DIFF
--- a/backend/src/main/java/de/fh_dortmund/swt2/backend/controller/AppUserController.java
+++ b/backend/src/main/java/de/fh_dortmund/swt2/backend/controller/AppUserController.java
@@ -2,11 +2,10 @@ package de.fh_dortmund.swt2.backend.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import org.springframework.security.core.Authentication;
 import de.fh_dortmund.swt2.backend.model.AppUser;
-import de.fh_dortmund.swt2.backend.security.JwtUtil;
+import de.fh_dortmund.swt2.backend.security.AppUserDetails;
 import de.fh_dortmund.swt2.backend.service.AppUserService;
-import de.fh_dortmund.swt2.backend.security.JwtUtil;
 
 @RestController
 @RequestMapping("api/user/me")
@@ -14,47 +13,54 @@ public class AppUserController {
     
     private final AppUserService appUserService;
 
-    private final JwtUtil jwtUtil;
 
-    public AppUserController(AppUserService appUserService, JwtUtil jwtUtil) {
+    public AppUserController(AppUserService appUserService) {
         this.appUserService = appUserService;
-        this.jwtUtil= jwtUtil;
     }
 
     // Gibt User-Profildaten zurück (NICHT history etc.)
     @GetMapping
-    public ResponseEntity<?> getUser(@RequestHeader("Authorization") String token){
-        AppUser user = jwtUtil.getUserFromToken(token);
+    public ResponseEntity<?> getUser(Authentication authentication){
+        AppUser user = extractAppUser(authentication);
         return ResponseEntity.ok(appUserService.getUserProfile(user));
     }
 
     // Speichert Inserat in saved-Liste ab
     @PostMapping("/saved/{id}")
-    public ResponseEntity<?> saveEstate(@RequestHeader("Authorization") String token, @PathVariable Long id){
-        AppUser user = jwtUtil.getUserFromToken(token);
+    public ResponseEntity<?> saveEstate(Authentication authentication, @PathVariable Long id){
+        AppUser user = extractAppUser(authentication);
         appUserService.saveEstate(user, id);
         return ResponseEntity.ok().build();
     }
 
     // Gibt Estates der saved-Liste zurück
     @GetMapping("/saved")
-    public ResponseEntity<?> getSaved(@RequestHeader("Authorization") String token){
-        AppUser user = jwtUtil.getUserFromToken(token);
+    public ResponseEntity<?> getSaved(Authentication authentication){
+        AppUser user = extractAppUser(authentication);
         return ResponseEntity.ok(appUserService.getSaved(user));
     }
 
     // Gibt Estates der history-Liste zurück
     @GetMapping("/history")
-    public ResponseEntity<?> getHistory(@RequestHeader("Authorization") String token){
-        AppUser user = jwtUtil.getUserFromToken(token);
+    public ResponseEntity<?> getHistory(Authentication authentication){
+        AppUser user = extractAppUser(authentication);
         return ResponseEntity.ok(appUserService.getHistory(user));
     }
 
     // Gibt Estates der realEstates-Liste zurück
     @GetMapping("/realEstates")
-    public ResponseEntity<?> getRealEstates(@RequestHeader("Authorization") String token){
-        AppUser user = jwtUtil.getUserFromToken(token);
+    public ResponseEntity<?> getRealEstates(Authentication authentication){
+        AppUser user = extractAppUser(authentication);
         return ResponseEntity.ok(appUserService.getRealEstates(user));
     }
 
+    // Hilfsmethode  Authentication statt manuelles Token-Parsen  nutzt Spring Security Context
+
+    private AppUser extractAppUser(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof AppUserDetails) {
+            return ((AppUserDetails) principal).getAppUser();
+        }
+        throw new IllegalStateException("Ungültiger Authentifizierungszustand");
+    }
 }


### PR DESCRIPTION
 I used the Authentication object from Spring Security to extract the currently authenticated user. This way, we avoid manually parsing the JWT token in the controller and instead leverage the existing security infrastructure provided by Spring Security
